### PR TITLE
Auto-uninstall the study after January 1st, 2018. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,6 @@ prototype for collecting these errors to aid in Firefox development.
 <dl>
   <dt>
     <code>
-      extensions.shield-study-js-errors@shield.mozilla.org.logLevel
-    </code>
-  </dt>
-  <dd>
-    Log level for extension logging. Defaults to Warnings and above. Set to 0
-    for verbose logging.
-  </dd>
-  <dt>
-    <code>
       extensions.shield-study-js-errors@shield.mozilla.org.testing
     </code>
   </dt>
@@ -39,6 +30,24 @@ prototype for collecting these errors to aid in Firefox development.
   <dd>
     Interval (in milliseconds) at which to submit collected error hashes to
     telemetry.
+  </dd>
+  <dt>
+    <code>
+      extensions.shield-study-js-errors@shield.mozilla.org.expirationDate
+    </code>
+  </dt>
+  <dd>
+    Date.parse-compatible string specifying the datetime that the experiment
+    should expire and automatically uninstall itself. Defaults to January 1st,
+    2018.
+  </dd>
+  <dt>
+    <code>
+      extensions.shield-study-js-errors@shield.mozilla.org.expirationIntervalMs
+    </code>
+  </dt>
+  <dd>
+    Interval (in milliseconds) at which to check whether the study has expired or not. Defaults to once per day.
   </dd>
 </dl>
 

--- a/extension/bootstrap.js
+++ b/extension/bootstrap.js
@@ -3,12 +3,35 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const {utils: Cu} = Components;
+Cu.import("resource://gre/modules/Services.jsm");
+Cu.import("resource://gre/modules/Timer.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 
+XPCOMUtils.defineLazyModuleGetter(this, "AddonManager", "resource://gre/modules/AddonManager.jsm");
 XPCOMUtils.defineLazyModuleGetter(
   this, "ErrorLogging", "resource://shield-study-js-errors/ErrorLogging.jsm");
 XPCOMUtils.defineLazyModuleGetter(
   this, "ErrorReporting", "resource://shield-study-js-errors/ErrorReporting.jsm");
+
+let expirationInterval = null;
+
+/**
+ * Uninstall the add-on if it is past the built-in expiration date.
+ */
+async function checkExpiration() {
+  const expirationDate = new Date(
+    Services.prefs.getCharPref(
+      "extensions.shield-study-js-errors@shield.mozilla.org.expirationDate",
+      "2018-01-01T00:00:00.000Z",
+    ),
+  );
+  if (new Date() > expirationDate) {
+    const addon = await AddonManager.getAddonByID("shield-study-js-errors@shield.mozilla.org");
+    if (addon) {
+      addon.uninstall();
+    }
+  }
+}
 
 this.install = function() {};
 
@@ -16,11 +39,23 @@ this.startup = function() {
   ErrorReporting.startup();
   ErrorLogging.startup();
   ErrorLogging.addListener(ErrorReporting.reportError.bind(ErrorReporting));
+
+  // Check expiration on startup, and again once per-day if necessary.
+  const expirationDelay = Services.prefs.getIntPref(
+    "extensions.shield-study-js-errors@shield.mozilla.org.expirationIntervalMs",
+    1000 * 60 * 60 * 24, // 1 day
+  );
+  expirationInterval = setInterval(checkExpiration, expirationDelay);
+  checkExpiration();
 };
 
 this.shutdown = function() {
   ErrorLogging.shutdown();
   ErrorReporting.shutdown();
+
+  if (expirationInterval) {
+    clearInterval(expirationInterval);
+  }
 
   Cu.unload("resource://shield-study-js-errors/ErrorLogging.jsm");
   Cu.unload("resource://shield-study-js-errors/ErrorReporting.jsm");


### PR DESCRIPTION
Adds backup expiration to the study in case Shield fails to uninstall it for whatever reason.

This depends on #2. 8a1c696 is the new commit.