### PR TITLE
Add basic CEP analysis counting successfully-received pings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ The purpose of the study is to measure the amount and distribution of browser
 chrome errors in a privacy-respectful way. The data will be used to create a
 prototype for collecting these errors to aid in Firefox development.
 
+## Dashboards
+
+- [Number of study pings received per-minute](https://pipeline-cep.prod.mozaws.net/dashboard_output/graphs/analysis.mkelly_mozilla_com.shield_study_js_errors_pings_received.JS_error_study_pings_per_minute.html)
+
 ## Preferences
 <dl>
   <dt>

--- a/analysis/pings-received.lua
+++ b/analysis/pings-received.lua
@@ -1,0 +1,33 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+--[[
+# JS Error Shield Study: Received Pings
+[CEP][] plugin that estimates the number of pings received over the past two
+days. This is mostly used as a sanity check that data is being sent
+successfully.
+
+[CEP]: https://docs.telemetry.mozilla.org/concepts/data_pipeline.html#hindsight
+
+## Sample Configuration
+```lua
+filename = 'shield-study-js-errors-pings-received.lua'
+message_matcher = 'Type=="telemetry" && Fields[docType]=="shield-study-addon" && Fields[submission]=~"\\"study_name\\":\\"shield%-study%-js%-errors\\""'
+preserve_data = true
+ticker_interval = 60
+```
+--]]
+require "circular_buffer"
+
+cb = circular_buffer.new(3600, 1, 60)
+cb:set_header(1, "success")
+
+function process_message()
+  cb:add(read_message("Timestamp"), 1, 1)
+  return 0
+end
+
+function timer_event()
+  inject_payload("cbuf", "JS error study pings per minute", cb)
+end


### PR DESCRIPTION
This will help us be confident that clients are actually sending pings successfully. The linked dashboard shows two successful pings I sent with my client set at a 120 second aggregation delay.

@mythmon Lemme know if you want me to find someone more familiar with CEP to check this.